### PR TITLE
Base block struct ndarray

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ nz = 10
 wedge = TubeBlockStruct(rs, ts, zs, nr, nt, nz, zone_tag='wedge')
 
 # Tag front and back boundaries
-wedge['boundary_tags'][..., 0, 2] = BoundaryTag('front')
-wedge['boundary_tags'][..., -1, 2] = BoundaryTag('back')
+wedge.boundary_tags[..., 0, 2] = BoundaryTag('front')
+wedge.boundary_tags[..., -1, 2] = BoundaryTag('back')
 
 # Initialize blockmeshbuilder to gather block structures.
 block_mesh_dict = BlockMeshDict(metric='mm', of_dist='.org')

--- a/blockmeshbuilder/builder.py
+++ b/blockmeshbuilder/builder.py
@@ -34,9 +34,9 @@ def np_cart_to_cyl(crds):
 	return ncrds
 
 
-class BaseBlockStruct(object):
+class BaseBlockStruct(np.recarray):
 
-	def __init__(self, x0, x1, x2, nd0, nd1, nd2, conv_func=cart_to_cart, zone_tag=DEFAULT_ZONE_TAG):
+	def __new__(cls, x0, x1, x2, nd0, nd1, nd2, conv_func=cart_to_cart, zone_tag=DEFAULT_ZONE_TAG):
 		x0 = np.asarray(x0)
 		x1 = np.asarray(x1)
 		x2 = np.asarray(x2)
@@ -90,38 +90,38 @@ class BaseBlockStruct(object):
 			raise TypeError(f'The zone_tag parameter was neither a string nor a ZoneTag.')
 
 		shape = (x0.size, x1.size, x2.size)
-		self.str_arr = np.empty(shape, dtype=block_struct_dtype)
-		self.rshape = rshape = (shape[0] - 1, shape[1] - 1, shape[2] - 1)
+		block_structure = super(BaseBlockStruct, cls).__new__(cls, shape, dtype=block_struct_dtype)
+		rshape = (shape[0] - 1, shape[1] - 1, shape[2] - 1)
 
 		# Initialize vertices
 		X0, X1, X2 = np.meshgrid(x0, x1, x2, indexing='ij')
 
-		vts = self['vertices']
+		vts = block_structure.vertices
 		vts[..., 0] = X0
 		vts[..., 1] = X1
 		vts[..., 2] = X2
 
-		for ind in np.ndindex(self.shape):
-			self['baked_vertices'][ind] = Vertex(vts[ind], conv_func)
+		for ind in np.ndindex(shape):
+			block_structure.baked_vertices[ind] = Vertex(vts[ind], conv_func)
 
 		# Initialize number of divisions
 		ND0, ND1, ND2 = np.meshgrid(nd0, nd1, nd2, indexing='ij')
 
-		nds = self['num_divisions']
+		nds = block_structure.num_divisions
 		nds[..., 0] = ND0
 		nds[..., 1] = ND1
 		nds[..., 2] = ND2
 
 		# Initialize grading
-		self['grading'][:] = uniformGradingElement
+		block_structure.grading[:] = uniformGradingElement
 
 		# Initialize edges and faces
 		for s in range(3):
 			roll_pos = np.roll(init_pos, s)
 
-			d_edges = np.moveaxis(self['edges'][..., s], init_pos, roll_pos)
-			d_faces = np.moveaxis(self['faces'][..., s], init_pos, roll_pos)
-			d_vts = np.moveaxis(self['baked_vertices'], init_pos, roll_pos)
+			d_edges = np.moveaxis(block_structure.edges[..., s], init_pos, roll_pos)
+			d_faces = np.moveaxis(block_structure.faces[..., s], init_pos, roll_pos)
+			d_vts = np.moveaxis(block_structure.baked_vertices, init_pos, roll_pos)
 
 			for i in range(rshape[s]):
 				for j in range(shape[(s + 1) % 3]):
@@ -133,7 +133,10 @@ class BaseBlockStruct(object):
 					for k in range(rshape[(s + 2) % 3]):
 						d_faces[i, j, k] = Face(d_vts[i, j:j + 2, k:k + 2])
 
-		self['zone_tags'][:] = zone_tag
+		block_structure.zone_tags[:] = zone_tag
+
+		return block_structure
+
 
 	def project_structure(self, dir, face_ind, geometry):
 
@@ -144,15 +147,15 @@ class BaseBlockStruct(object):
 		shape = struct.shape
 
 		# Project vertices
-		b_vts = struct['baked_vertices']
-		vt_mask = struct['vertex_mask']
+		b_vts = struct.baked_vertices
+		vt_mask = struct.vertex_mask
 		for ind in np.ndindex(shape):
 			if not vt_mask[ind]:
 				b_vts[ind].proj_geom(geometry)
 
 		# Project edges
-		edges = np.roll(struct['edges'], -dir, axis=-1)[..., 1:]
-		edge_mask = np.roll(struct['edge_mask'], -dir, axis=-1)[..., 1:]
+		edges = np.roll(struct.edges, -dir, axis=-1)[..., 1:]
+		edge_mask = np.roll(struct.edge_mask, -dir, axis=-1)[..., 1:]
 		for j in range(shape[0]):
 			for k in range(shape[1]):
 				for s in range(2):
@@ -161,8 +164,8 @@ class BaseBlockStruct(object):
 						edge.proj_geom(geometry)
 
 		# Project faces
-		faces = struct['faces'][..., dir]
-		face_mask = struct['face_mask'][..., dir]
+		faces = struct.faces[..., dir]
+		face_mask = struct.face_mask[..., dir]
 		for j in range(rshape[0]):
 			for k in range(rshape[1]):
 				if not face_mask[j, k]:
@@ -200,36 +203,36 @@ class BaseBlockStruct(object):
 	def write(self, block_mesh_dict):
 
 		# Reset block_mask edge
-		bmask = self['block_mask']
+		bmask = self.block_mask
 		bmask[-1] = True
 		bmask[:, -1] = True
 		bmask[:, :, -1] = True
 
+		shape = self.shape
+		rshape = (shape[0] - 1, shape[1] - 1, shape[2] - 1)
+
 		# TO DO: See if numpy moving_window function will help here
-		for i in range(self.rshape[0]):
-			for j in range(self.rshape[1]):
-				for k in range(self.rshape[2]):
+		for i in range(rshape[0]):
+			for j in range(rshape[1]):
+				for k in range(rshape[2]):
 
 					if not bmask[i, j, k]:
 						# Get sub-array
 						blockData = self[i:i + 2, j:j + 2, k:k + 2]
 
-						gt = blockData['grading'].copy()
+						gt = blockData.grading.copy()
 						grading = self._get_grading(gt)
 
-						nd = blockData['num_divisions'][0, 0, 0]
+						nd = blockData.num_divisions[0, 0, 0]
 
-						vts = self._get_block_vertices(blockData['baked_vertices'])
+						vts = self._get_block_vertices(blockData.baked_vertices)
 
-						block_zone_tag = blockData['zone_tags'][0, 0, 0]
+						block_zone_tag = blockData.zone_tags[0, 0, 0]
 
 						block = HexBlock(vts, nd, block_zone_tag, grading)
 						block_mesh_dict.add_hexblock(block)
 
-		shape = self.shape
-		rshape = self.rshape
-
-		b_vts = self['baked_vertices']
+		b_vts = self.baked_vertices
 		for index in np.ndindex(shape):
 			block_mesh_dict.add_geometries(b_vts[index].proj_g)
 
@@ -238,9 +241,9 @@ class BaseBlockStruct(object):
 			roll_pos = np.roll(init_pos, s)
 
 			d_bmask = np.moveaxis(bmask, init_pos, roll_pos)
-			d_edges = np.moveaxis(self['edges'][..., s], init_pos, roll_pos)
-			d_faces = np.moveaxis(self['faces'][..., s], init_pos, roll_pos)
-			d_boundary_tags = np.moveaxis(self['boundary_tags'][..., s], init_pos, roll_pos)
+			d_edges = np.moveaxis(self.edges[..., s], init_pos, roll_pos)
+			d_faces = np.moveaxis(self.faces[..., s], init_pos, roll_pos)
+			d_boundary_tags = np.moveaxis(self.boundary_tags[..., s], init_pos, roll_pos)
 
 			for i in range(rshape[s]):
 				for j in range(shape[(s + 1) % 3]):
@@ -268,7 +271,7 @@ class BaseBlockStruct(object):
 								if i > 0 and lmsk.sum() == 0:
 									warnings.warn(
 										f'Attempting to specify a boundary at an interior face. '
-										f'Please check boundary_tags')
+										f'Please check assignment to boundary_tags.')
 								else:
 									block_mesh_dict.add_boundary_face(d_boundary_tags[i, j, k], face)
 
@@ -276,18 +279,9 @@ class BaseBlockStruct(object):
 								block_mesh_dict.add_face(face)
 								block_mesh_dict.add_geometries((face.proj_g,))
 
-	# Default to underlying structured array
-	def __getattr__(self, name):
-		return getattr(self.str_arr, name)
 
-	def __getitem__(self, key):
-		return self.str_arr[key]
-
-
-class CartBlockStruct(BaseBlockStruct):
-
-	def __init__(self, xs, ys, zs, nx, ny, nz, zone_tag=DEFAULT_ZONE_TAG):
-		BaseBlockStruct.__init__(self, xs, ys, zs, nx, ny, nz, cart_to_cart, zone_tag)
+# There is truly no need to subclass the BaseBlockStruct into CartBlockStruct
+CartBlockStruct = BaseBlockStruct
 
 
 class TubeBlockStruct(BaseBlockStruct):
@@ -312,9 +306,9 @@ class TubeBlockStruct(BaseBlockStruct):
 
 		BaseBlockStruct.__init__(self, rs, ts, zs, nr, nt, nz, cyl_to_cart, zone_tag)
 
-		b_vts = self['baked_vertices']
-		edges = self['edges']
-		faces = self['faces']
+		b_vts = self.baked_vertices
+		edges = self.edges
+		faces = self.faces
 		rshape = self.rshape
 
 		if is_complete:
@@ -325,8 +319,8 @@ class TubeBlockStruct(BaseBlockStruct):
 		# Re-assign vertices, edges, and faces at the axis of the tube
 		if self.is_full:
 			b_vts[0] = b_vts[0, 0]
-			self['face_mask'][0, ..., 0] = True
-			self['edge_mask'][0, ..., 1] = True
+			self.face_mask[0, ..., 0] = True
+			self.edge_mask[0, ..., 1] = True
 
 			for j in range(rshape[1] + 1):
 				for k in range(rshape[2] + 1):
@@ -343,7 +337,7 @@ class TubeBlockStruct(BaseBlockStruct):
 		shape = self.shape
 		shp = tuple((shape[0], shape[1] - 1, shape[2]))
 
-		vts = self['vertices']
+		vts = self.vertices
 
 		isR0 = np.isclose(vts[0, ..., 0], 0.)
 
@@ -364,20 +358,20 @@ class TubeBlockStruct(BaseBlockStruct):
 		# Mask axial and radial edges as well as circumferential faces so
 		# no redundant edges or faces are written to file
 		if self.is_complete:
-			self['edge_mask'][:, -1, :, [0, 2]] = True
-			self['face_mask'][:, -1, :, 1] = True
+			self.edge_mask[:, -1, :, [0, 2]] = True
+			self.face_mask[:, -1, :, 1] = True
 
-		b_vts = self['baked_vertices']
-		vertex_mask = self['vertex_mask']
-		proj_rcrds = self['vertices'][..., 0]
+		b_vts = self.baked_vertices
+		vertex_mask = self.vertex_mask
+		proj_rcrds = self.vertices[..., 0]
 
 		for ind in np.ndindex(shp):
 			if not (vertex_mask[ind] or np.isclose(proj_rcrds[ind], 0.)):
 				b_vts[ind].proj_geom(cyls[proj_rcrds[ind]])
 
-		edges = self['edges']
-		edge_mask = self['edge_mask']
-		acrds = self['vertices'][..., 1]
+		edges = self.edges
+		edge_mask = self.edge_mask
+		acrds = self.vertices[..., 1]
 
 		# Test and see if the circumferential edges or axial edges need to be projected
 		a_edges = edges[..., 2]
@@ -447,14 +441,14 @@ class CylBlockStructContainer(object):
 		self.core_struct = CartBlockStruct(xs, ys, zs, nx, ny, nz, zone_tag=zone_tag)
 
 		if is_core_aligned:  # Rotate the tube to match the core
-			self.tube_struct['vertices'][..., 1] -= 3 / 4 * np.pi
+			self.tube_struct.vertices[..., 1] -= 3 / 4 * np.pi
 		else:  # Rotate the core to match the tube
-			cyl_vts = np_cart_to_cyl(self.core_struct['vertices'])
+			cyl_vts = np_cart_to_cyl(self.core_struct.vertices)
 			cyl_vts[..., 1] -= 5 / 4 * np.pi
-			self.core_struct['vertices'][:] = np_cyl_to_cart(cyl_vts)
+			self.core_struct.vertices[:] = np_cyl_to_cart(cyl_vts)
 
-		core_b_vts = self.core_struct['baked_vertices']
-		tube_b_vts = self.tube_struct['baked_vertices']
+		core_b_vts = self.core_struct.baked_vertices
+		tube_b_vts = self.tube_struct.baked_vertices
 
 		# Connect the outer tube structure to the core
 		tube_indices = np.arange(ts.size - 1).reshape(4, Ng - 1)
@@ -466,8 +460,8 @@ class CylBlockStructContainer(object):
 
 	def write(self, block_mesh_dict):
 
-		self.tube_struct['face_mask'][0, :, :, 0] = True
-		self.tube_struct['vertex_mask'][0, :, :] = True
+		self.tube_struct.face_mask[0, :, :, 0] = True
+		self.tube_struct.vertex_mask[0, :, :] = True
 
 		iac = self.inner_arc_curve
 		og_vectors = self._og_core_vectors if self.is_core_aligned else self._og_tube_vectors
@@ -476,8 +470,8 @@ class CylBlockStructContainer(object):
 			tube = self.tube_struct
 			shape = tube.shape
 
-			tube_vts = tube['vertices'][0]
-			tube['edges'][0, ..., 1:] = dummy_edge
+			tube_vts = tube.vertices[0]
+			tube.edges[0, ..., 1:] = dummy_edge
 
 			core = self.core_struct
 
@@ -501,8 +495,8 @@ class CylBlockStructContainer(object):
 
 			# For each edge of the O-grid square
 			for s in range(4):
-				core_side_b_vts = np.rot90(core['baked_vertices'], k=-s)[:-1, 0, :]
-				core_side_edges = np.rot90(core['edges'], k=-s)[::np.sign(3 - (2 * s)), 0, :, s % 2][:-1]
+				core_side_b_vts = np.rot90(core.baked_vertices, k=-s)[:-1, 0, :]
+				core_side_edges = np.rot90(core.edges, k=-s)[::np.sign(3 - (2 * s)), 0, :, s % 2][:-1]
 
 				for index, core_vertex in np.ndenumerate(core_side_b_vts):
 					core_vertex.proj_geom(cyl_arr[index[1], s])
@@ -511,7 +505,7 @@ class CylBlockStructContainer(object):
 					edge.proj_geom(cyl_arr[index[1], s])
 
 		else:
-			self.tube_struct['edge_mask'][0, :, :, [1, 2]] = True
+			self.tube_struct.edge_mask[0, :, :, [1, 2]] = True
 
 		self.tube_struct.write(block_mesh_dict)
 		self.core_struct.write(block_mesh_dict)

--- a/blockmeshbuilder/builder.py
+++ b/blockmeshbuilder/builder.py
@@ -138,13 +138,13 @@ class BaseBlockStruct(np.recarray):
 		return block_structure
 
 
-	def project_structure(self, dir, face_ind, geometry):
+	def project_structure(self, direction, geometry, face_ind):
 
 		# Get the subarray relevant to the face being projected
-		roll_pos = np.roll(init_pos, dir)
-		struct = np.moveaxis(self.str_arr, init_pos, roll_pos)[face_ind]
-		rshape = np.roll(np.array(self.rshape), -dir)[1:]
+		roll_pos = np.roll(init_pos, direction)
+		struct = np.moveaxis(self, init_pos, roll_pos)[face_ind]
 		shape = struct.shape
+		rshape = np.roll(np.array(self.shape) - 1, -direction)[1:]
 
 		# Project vertices
 		b_vts = struct.baked_vertices
@@ -154,8 +154,8 @@ class BaseBlockStruct(np.recarray):
 				b_vts[ind].proj_geom(geometry)
 
 		# Project edges
-		edges = np.roll(struct.edges, -dir, axis=-1)[..., 1:]
-		edge_mask = np.roll(struct.edge_mask, -dir, axis=-1)[..., 1:]
+		edges = np.roll(struct.edges, -direction, axis=-1)[..., 1:]
+		edge_mask = np.roll(struct.edge_mask, -direction, axis=-1)[..., 1:]
 		for j in range(shape[0]):
 			for k in range(shape[1]):
 				for s in range(2):
@@ -164,8 +164,8 @@ class BaseBlockStruct(np.recarray):
 						edge.proj_geom(geometry)
 
 		# Project faces
-		faces = struct.faces[..., dir]
-		face_mask = struct.face_mask[..., dir]
+		faces = struct.faces[..., direction]
+		face_mask = struct.face_mask[..., direction]
 		for j in range(rshape[0]):
 			for k in range(rshape[1]):
 				if not face_mask[j, k]:

--- a/blockmeshbuilder/builder.py
+++ b/blockmeshbuilder/builder.py
@@ -442,18 +442,22 @@ class CylBlockStructContainer(object):
 							 f'which is too close to 0, such that an o-grid cannot be accomodated. '
 							 f'Consider using TubeBlockStruct instead.')
 
+		if (len(ts) - 1) % 4 > 0:
+			raise ValueError(f'The ts array length provided to CylBlockStructContainer is invalid. In order to make '
+							 f'sure the o-grid is properly formed, the number of divisions must be `4*n+1`, where `n` '
+							 f'is any positive integer.')
+
 		self.inner_arc_curve = inner_arc_curve
 		self.is_core_aligned = is_core_aligned
 
-		Ng = ((ts.size - 1) // 4) + 1  # Assume integer number of divisions
-
-		xs = ys = np.linspace(-rs[0], rs[0], Ng) * _drt2
+		num_side_blocks = (len(ts) - 1) // 4
+		xs = ys = np.linspace(-rs[0], rs[0], num_side_blocks + 1) * _drt2
 
 		if isinstance(nt, int):
 			nx = ny = nt
 		else:
-			nx = nt[:Ng].copy()
-			ny = nt[Ng:2 * Ng].copy()
+			nx = nt[:num_side_blocks]
+			ny = nt[num_side_blocks:2 * num_side_blocks]
 
 		self.core_struct = CartBlockStruct(xs, ys, zs, nx, ny, nz, zone_tag=zone_tag)
 
@@ -468,7 +472,7 @@ class CylBlockStructContainer(object):
 		tube_b_vts = self.tube_struct.baked_vertices
 
 		# Connect the outer tube structure to the core
-		tube_indices = np.arange(ts.size - 1).reshape(4, Ng - 1)
+		tube_indices = np.arange(ts.size - 1).reshape(4, num_side_blocks)
 
 		for s in range(4):
 			tube_b_vts[0, tube_indices[s], :] = np.rot90(core_b_vts, k=-s)[:-1, 0, :]

--- a/blockmeshbuilder/builder.py
+++ b/blockmeshbuilder/builder.py
@@ -137,7 +137,6 @@ class BaseBlockStruct(np.recarray):
 
 		return block_structure
 
-
 	def project_structure(self, direction, geometry, face_ind):
 
 		# Get the subarray relevant to the face being projected
@@ -333,6 +332,20 @@ class TubeBlockStruct(BaseBlockStruct):
 		block_structure.is_complete = is_complete
 
 		return block_structure
+
+	def __array_finalize__(self, other_block_structure):
+		if (other_block_structure is None) or (self.dtype is not other_block_structure.dtype):
+			return
+
+		# Right now this function gets called 3 times after slicing by recarray internals,
+		# but it shouldn't impact the user
+
+		# Assume index ordering hasn't been changed using a function such as np.moveaxis
+		self.is_complete = other_block_structure.is_complete and \
+						   np.all(self.baked_vertices[:, 0] == self.baked_vertices[:, -1])
+
+		self.is_full = other_block_structure.is_full and \
+					   np.all(np.isin(self.baked_vertices[0], other_block_structure.baked_vertices[0]))
 
 	def write(self, block_mesh_dict):
 

--- a/blockmeshbuilder/builder.py
+++ b/blockmeshbuilder/builder.py
@@ -286,7 +286,7 @@ CartBlockStruct = BaseBlockStruct
 
 class TubeBlockStruct(BaseBlockStruct):
 
-	def __init__(self, rs, ts, zs, nr, nt, nz, zone_tag=DEFAULT_ZONE_TAG, is_complete=False):
+	def __new__(cls, rs, ts, zs, nr, nt, nz, zone_tag=DEFAULT_ZONE_TAG, is_complete=False):
 
 		if np.any(np.asarray(rs) < 0):
 			raise ValueError('Negative values supplied to array of radial values in TubeBlockStruct.')
@@ -304,23 +304,23 @@ class TubeBlockStruct(BaseBlockStruct):
 						  f'The resulting tube struct may visually appear closed, but a circumferential \'wall\' '
 						  f'will be present at theta={ts[0]}.')
 
-		BaseBlockStruct.__init__(self, rs, ts, zs, nr, nt, nz, cyl_to_cart, zone_tag)
+		block_structure = super(TubeBlockStruct, cls).__new__(cls, rs, ts, zs, nr, nt, nz, cyl_to_cart, zone_tag)
 
-		b_vts = self.baked_vertices
-		edges = self.edges
-		faces = self.faces
-		rshape = self.rshape
+		b_vts = block_structure.baked_vertices
+		edges = block_structure.edges
+		faces = block_structure.faces
+		rshape = np.array(block_structure.shape) - 1
 
 		if is_complete:
 			b_vts[:, -1] = b_vts[:, 0]
 
-		self.is_full = np.isclose(rs[0], 0.)
+		block_structure.is_full = np.isclose(rs[0], 0.)
 
 		# Re-assign vertices, edges, and faces at the axis of the tube
-		if self.is_full:
+		if block_structure.is_full:
 			b_vts[0] = b_vts[0, 0]
-			self.face_mask[0, ..., 0] = True
-			self.edge_mask[0, ..., 1] = True
+			block_structure.face_mask[0, ..., 0] = True
+			block_structure.edge_mask[0, ..., 1] = True
 
 			for j in range(rshape[1] + 1):
 				for k in range(rshape[2] + 1):
@@ -330,7 +330,9 @@ class TubeBlockStruct(BaseBlockStruct):
 				for k in range(rshape[2]):
 					faces[0, j, k, 1] = Face(b_vts[0:2, j, k:k + 2])
 
-		self.is_complete = is_complete
+		block_structure.is_complete = is_complete
+
+		return block_structure
 
 	def write(self, block_mesh_dict):
 

--- a/examples/airfoil.py
+++ b/examples/airfoil.py
@@ -91,7 +91,6 @@ bl_struct.vertices[0, -1, :, 1] = num_chords_bl_thickness
 
 # Construct trailing edge block if necessary
 far_field_zone_tag = ZoneTag('far_field')
-te_struct = None
 if close_trailing_edge:
 	bl_struct.baked_vertices[-1, [-1, -2]] = bl_struct.baked_vertices[-1, [0, 1]]
 else:
@@ -130,7 +129,7 @@ ff_struct.boundary_tags[0, ..., 0] = BoundaryTag('inlet')
 outlet_tag = BoundaryTag('outlet')
 ff_struct.boundary_tags[-1, [0, -2], :, 0] = outlet_tag
 bl_struct.boundary_tags[0, [0, -1], :, 1] = outlet_tag
-if te_struct:
+if not close_trailing_edge:
 	te_struct.boundary_tags[:, 0, :, 1] = outlet_tag
 
 bl_struct.boundary_tags[-1, 1:-2, :, 0] = BoundaryTag('wall-airfoil')
@@ -139,7 +138,7 @@ bl_struct.boundary_tags[-1, 1:-2, :, 0] = BoundaryTag('wall-airfoil')
 block_mesh_dict = BlockMeshDict(metric='mm')
 bl_struct.write(block_mesh_dict)
 ff_struct.write(block_mesh_dict)
-if te_struct:
+if not close_trailing_edge:
 	te_struct.write(block_mesh_dict)
 block_mesh_dict.write_file('OF_case/system/')  # Try adding block_structure_only=True here
 

--- a/examples/airfoil.py
+++ b/examples/airfoil.py
@@ -69,11 +69,11 @@ lb_nose_index = (np.abs(bl_slope - m_slope)).argmin()
 sb_idx = [0, l_nose_index, u_nose_index, -1]
 bb_idx = [0, lb_nose_index, ub_nose_index, -1]
 
-bl_struct['vertices'][-1, 1:5, :, :2] = s_pts[sb_idx][:, np.newaxis]
-bl_struct['vertices'][0, 1:5, :, :2] = bl_pts[bb_idx][:, np.newaxis]
+bl_struct.vertices[-1, 1:5, :, :2] = s_pts[sb_idx][:, np.newaxis]
+bl_struct.vertices[0, 1:5, :, :2] = bl_pts[bb_idx][:, np.newaxis]
 
-bl_edges = bl_struct['edges']
-bl_b_vts = bl_struct['baked_vertices']
+bl_edges = bl_struct.edges
+bl_b_vts = bl_struct.baked_vertices
 
 for j in range(1, 4):
 	for k in range(zs.size):
@@ -84,20 +84,20 @@ for j in range(1, 4):
 		bl_edges[-1, j, k, 1] = PolyLineCurvedEdge(bl_b_vts[-1, j:j + 2, k], pts)
 
 # Align downstream boundary layer block structure
-bl_struct['vertices'][:, [0, -1], :, 0] = 1 + num_chords_downstream
-bl_struct['vertices'][0, 0, :, 1] = -num_chords_bl_thickness
-bl_struct['vertices'][-1, [0, -1], :, 1] = bl_struct['vertices'][-1, [1, -2], :, 1]
-bl_struct['vertices'][0, -1, :, 1] = num_chords_bl_thickness
+bl_struct.vertices[:, [0, -1], :, 0] = 1 + num_chords_downstream
+bl_struct.vertices[0, 0, :, 1] = -num_chords_bl_thickness
+bl_struct.vertices[-1, [0, -1], :, 1] = bl_struct.vertices[-1, [1, -2], :, 1]
+bl_struct.vertices[0, -1, :, 1] = num_chords_bl_thickness
 
 # Construct trailing edge block if necessary
 far_field_zone_tag = ZoneTag('far_field')
 te_struct = None
 if close_trailing_edge:
-	bl_struct['baked_vertices'][-1, [-1, -2]] = bl_struct['baked_vertices'][-1, [0, 1]]
+	bl_struct.baked_vertices[-1, [-1, -2]] = bl_struct.baked_vertices[-1, [0, 1]]
 else:
 	te_struct = CartBlockStruct([0, 1], [0, 1], zs, 3, nx_downstream, ndz, zone_tag=far_field_zone_tag)
-	te_struct['baked_vertices'][0] = bl_struct['baked_vertices'][-1, :2]
-	te_struct['baked_vertices'][-1] = bl_struct['baked_vertices'][-1, -2:][::-1]
+	te_struct.baked_vertices[0] = bl_struct.baked_vertices[-1, :2]
+	te_struct.baked_vertices[-1] = bl_struct.baked_vertices[-1, -2:][::-1]
 
 # Create the far-field structure
 ff_xs = np.array([-num_chords_upstream, 0., 1., 1 + num_chords_downstream])
@@ -109,31 +109,31 @@ ff_ndy = np.array([ny_wall_normal, n_nose, ny_wall_normal])
 ff_struct = CartBlockStruct(ff_xs, ff_ys, zs, ff_ndx, ff_ndy, ndz, zone_tag=far_field_zone_tag)
 
 # Cut out the center of the far-field struct for the boundary layer struct to fit
-ff_struct['block_mask'][1:, 1, :] = True
+ff_struct.block_mask[1:, 1, :] = True
 
 # Mate far-field structure to boundary layer structure
-ff_struct['baked_vertices'][1:, 1] = bl_struct['baked_vertices'][0, 2::-1]
-ff_struct['baked_vertices'][1:, 2] = bl_struct['baked_vertices'][0, 3:]
+ff_struct.baked_vertices[1:, 1] = bl_struct.baked_vertices[0, 2::-1]
+ff_struct.baked_vertices[1:, 2] = bl_struct.baked_vertices[0, 3:]
 
 # Mesh tuning
-bl_struct['grading'][0, ..., 0] = SimpleGradingElement(1./2)
+bl_struct.grading[0, ..., 0] = SimpleGradingElement(1./2)
 
 len_pcts = np.array([0.8, 0.2])
 dens = np.array([1., 1., 3.])
-ff_struct['grading'][0, ..., 0] = MultiGradingElement(*get_grading_info(len_pcts, dens))
-ff_struct['grading'][:, 0, :, 1] = MultiGradingElement(*get_grading_info(len_pcts, dens))
-ff_struct['grading'][:, 2, :, 1] = MultiGradingElement(*get_grading_info(len_pcts[::-1], dens[::-1]))
+ff_struct.grading[0, ..., 0] = MultiGradingElement(*get_grading_info(len_pcts, dens))
+ff_struct.grading[:, 0, :, 1] = MultiGradingElement(*get_grading_info(len_pcts, dens))
+ff_struct.grading[:, 2, :, 1] = MultiGradingElement(*get_grading_info(len_pcts[::-1], dens[::-1]))
 
 # Define boundary_tags
-ff_struct['boundary_tags'][0, ..., 0] = BoundaryTag('inlet')
+ff_struct.boundary_tags[0, ..., 0] = BoundaryTag('inlet')
 
 outlet_tag = BoundaryTag('outlet')
-ff_struct['boundary_tags'][-1, [0, -2], :, 0] = outlet_tag
-bl_struct['boundary_tags'][0, [0, -1], :, 1] = outlet_tag
+ff_struct.boundary_tags[-1, [0, -2], :, 0] = outlet_tag
+bl_struct.boundary_tags[0, [0, -1], :, 1] = outlet_tag
 if te_struct:
-	te_struct['boundary_tags'][:, 0, :, 1] = outlet_tag
+	te_struct.boundary_tags[:, 0, :, 1] = outlet_tag
 
-bl_struct['boundary_tags'][-1, 1:-2, :, 0] = BoundaryTag('wall-airfoil')
+bl_struct.boundary_tags[-1, 1:-2, :, 0] = BoundaryTag('wall-airfoil')
 
 # Write the blocks to the blockMeshDict
 block_mesh_dict = BlockMeshDict(metric='mm')

--- a/examples/cyl_struct.py
+++ b/examples/cyl_struct.py
@@ -4,11 +4,17 @@ import numpy as np
 from blockmeshbuilder import BlockMeshDict, CylBlockStructContainer, BoundaryTag
 
 rs = np.array([0.3, 0.6, 1.0])
-ts = np.linspace(0, 2 * np.pi, 13, endpoint=True)  # Try any 4*n+1, where n is a positive int.
+num_side_blocks = 3  # Must be a positive integer
+ts = np.linspace(0, 2 * np.pi, num_side_blocks * 4 + 1, endpoint=True)
 zs = np.array([0.0, 0.5, 1.5])
 
 ndr = 6
-ndt = 6
+
+# Specify node counts of circumferential blocks; as with other structures len(ndt) == len(ts) or len(ndt) = len(ts) - 1
+nd1 = [2, 3, 4]  # Node counts for successive blocks in x direction
+nd2 = [5, 6, 7]  # Node counts for successive blocks in y direction
+ndt = nd1 + nd2 + nd1[::-1] + nd2[::-1]  # Specifying the node counts in this way preserves the o-grid anti-symmetry
+
 ndz = 8
 
 iac = 0.45

--- a/examples/cyl_struct.py
+++ b/examples/cyl_struct.py
@@ -16,13 +16,13 @@ cyl = CylBlockStructContainer(rs, ts, zs, ndr, ndt, ndz, zone_tag='ts', is_core_
 
 # Increase size of back half
 scale = 1.15
-cyl.tube_struct['vertices'][:, :, 1:, 0] *= scale		# Scale tube radii
-cyl.core_struct['vertices'][:, :, 1:, [0, 1]] *= scale	# Scale core x and y co-ordinates
+cyl.tube_struct.vertices[:, :, 1:, 0] *= scale		# Scale tube radii
+cyl.core_struct.vertices[:, :, 1:, [0, 1]] *= scale	# Scale core x and y co-ordinates
 
 # Twist the outermost shell of the tube block structure
-cyl.tube_struct['vertices'][-1, :-1, -1, 1] += np.pi / 16
+cyl.tube_struct.vertices[-1, :-1, -1, 1] += np.pi / 16
 
-cyl.tube_struct['boundary_tags'][-1, ..., 0] = BoundaryTag('wall')
+cyl.tube_struct.boundary_tags[-1, ..., 0] = BoundaryTag('wall')
 
 block_mesh_dict = BlockMeshDict(metric='mm')
 cyl.write(block_mesh_dict)

--- a/examples/masking.py
+++ b/examples/masking.py
@@ -14,7 +14,7 @@ ndx = ndy = ndz = 8
 f_struct = CartBlockStruct(xs, ys, zs, ndx, ndy, ndz, zone_tag='f_struct')
 
 # Mask structure
-f_struct['block_mask'][:-1, :-1, :] = np.array(
+f_struct.block_mask[:-1, :-1, :] = np.array(
 	[[0, 0, 0],
 	 [0, 1, 1],
 	 [0, 0, 0],
@@ -25,18 +25,18 @@ ixs = np.linspace(1., 1.5, 2) + 0.1
 i_struct = CartBlockStruct(ixs, ys + 0.5, zs, ndx, ndy, ndz, zone_tag='i_struct')
 
 # Align the x and y co-ordinates of the relevant i_struct blocks with the f_struct prior to mating
-i_struct['vertices'][..., 0] -= 0.1  # x co-ordinates
-i_struct['vertices'][:, :-2, :, 1] = f_struct['vertices'][-1, 2:, :, 1][np.newaxis, ...]  # y co-ordinates
+i_struct.vertices[..., 0] -= 0.1  # x co-ordinates
+i_struct.vertices[:, :-2, :, 1] = f_struct.vertices[-1, 2:, :, 1][np.newaxis, ...]  # y co-ordinates
 
 # Mate the structures by setting the relevant vertex objects (or 'baked_vertices') equal to one another
-i_struct['baked_vertices'][0, :-2, :] = f_struct['baked_vertices'][-1, 2:, :]
+i_struct.baked_vertices[0, :-2, :] = f_struct.baked_vertices[-1, 2:, :]
 
 # When blockmeshbuilder writes this blockMeshDict, it will use the same vertices, and therefore will identify
 # common edges and faces of the mated blocks, and treat them as a contiguous structure.
 
 # After the blocks are mated, the mated vertices are only modifiable through the f_struct.
-f_struct['vertices'][-1, 2:, :, 1] += 0.1  # This line moves the mated vertices up
-i_struct['vertices'][0, :-2, :, 1] -= 0.2  # This line does nothing
+f_struct.vertices[-1, 2:, :, 1] += 0.1  # This line moves the mated vertices up
+i_struct.vertices[0, :-2, :, 1] -= 0.2  # This line does nothing
 
 # Write to file
 block_mesh_dict = BlockMeshDict(metric='mm')

--- a/examples/rect_struct.py
+++ b/examples/rect_struct.py
@@ -71,7 +71,7 @@ plane_point = Point([0., 0, 0.])
 plane_normal = Point([-1., -1., 0.])
 plane = PlanePointAndNormal(plane_point, plane_normal, 'plane')
 
-rect_struct.project_structure(0, plane)
+rect_struct.project_structure(0, plane, 0)
 
 # Create a spline edge 'awning' to top the 'doorway'
 vertices = rect_struct.vertices

--- a/examples/rect_struct.py
+++ b/examples/rect_struct.py
@@ -24,14 +24,14 @@ rect_struct = CartBlockStruct(xs, ys, zs, ndx, ndy, ndz, zone_tag='test_zone')
 # is to be changed.
 
 # Move the top nodes of the first block upward
-rect_struct['vertices'][:2, -1, :, 1] += 0.25
+rect_struct.vertices[:2, -1, :, 1] += 0.25
 
 # The above statement applies to the first two nodes in the x-direction (:2), the last nodes in the y-direction (-1),
 # all the nodes in the z-direction (:), and the final index selects the y-component of those nodes (1).
 # The right hand expression adds the offset value to the sliced array.
 
 # We can also apply this to other features of the mesh we want local control over, such as the grading:
-GD = rect_struct['grading']
+GD = rect_struct.grading
 
 # All edges on the first two rows of blocks graded in the y-direction
 GD[:, 0, :, 1] = SimpleGradingElement(1.0 / 3)
@@ -64,17 +64,17 @@ GD[1, :, :, 0] = grd_elm
 
 # Remove the block at the (1,0,0) index. Notice 3 indices are needed
 # this time since blocks don't have an explicit position.
-rect_struct['block_mask'][1, 0, :] = True
+rect_struct.block_mask[1, 0, :] = True
 
 # Project the left side to a plane
 plane_point = Point([0., 0, 0.])
 plane_normal = Point([-1., -1., 0.])
 plane = PlanePointAndNormal(plane_point, plane_normal, 'plane')
 
-rect_struct.project_structure(0, 0, plane)
+rect_struct.project_structure(0, plane)
 
 # Create a spline edge 'awning' to top the 'doorway'
-vertices = rect_struct['vertices']
+vertices = rect_struct.vertices
 door_x_coordinates = vertices[1:3, 1, -1, 0]
 door_x_values = np.linspace(door_x_coordinates[0], door_x_coordinates[1], 5, endpoint=True)
 door_center = np.average(door_x_coordinates)
@@ -85,11 +85,11 @@ norm_x = (door_x_values - door_center) * 2 / np.diff(door_x_coordinates)[0]
 door_top_spline_coords[:, 2] += 0.05 * (1.1 - norm_x**4)
 door_top_spline_pts = [Point(c) for c in door_top_spline_coords]
 
-door_top_baked_vts = rect_struct['edges'][1, 1, -1, 0].vertices
-rect_struct['edges'][1, 1, -1, 0] = BSplineCurvedEdge(door_top_baked_vts, door_top_spline_pts)
+door_top_baked_vts = rect_struct.edges[1, 1, -1, 0].vertices
+rect_struct.edges[1, 1, -1, 0] = BSplineCurvedEdge(door_top_baked_vts, door_top_spline_pts)
 
 # Create a cylinder geometry along the right hand side of the block structure
-vts = rect_struct['vertices'][-1]
+vts = rect_struct.vertices[-1]
 rad = (zs[-1] - zs[0]) / 2
 pt1 = Point([xs[-1], -2, zs[1]])
 pt2 = Point([xs[-1], 2, zs[1]])
@@ -99,7 +99,7 @@ cyl = Cylinder(pt1, pt2, rad, 'cyl')
 vts[:, 1, 0] += 0.1
 
 # project the right side of the block structure onto the cylinder.
-rect_struct.project_structure(0, -1, cyl)
+rect_struct.project_structure(0, cyl, -1)
 
 # Write the blocks to the blockMeshDict
 block_mesh_dict = BlockMeshDict(metric='mm')

--- a/examples/tube_struct.py
+++ b/examples/tube_struct.py
@@ -15,12 +15,12 @@ ndz = 8
 tube = TubeBlockStruct(rs, ts, zs, ndr, ndt, ndz, zone_tag='tube', is_complete=is_complete)
 
 alternate_blocks = tube[1:, 1::2, 3:]
-alternate_blocks['edge_mask'][..., 1:, 1] = True
-alternate_blocks['face_mask'][..., 0] = True
+alternate_blocks.edge_mask[..., 1:, 1] = True
+alternate_blocks.face_mask[..., 0] = True
 
-tube['vertices'][-1, :-1, 0, 1] += np.pi / 16
-tube['vertices'][-1, :-1, [2, 3], 1] -= np.pi / 16
-tube['vertices'][-1, :-1, [2, 3], 0] += 0.2		# Produces correct conical surface for of_dist='.com'
+tube.vertices[-1, :-1, 0, 1] += np.pi / 16
+tube.vertices[-1, :-1, [2, 3], 1] -= np.pi / 16
+tube.vertices[-1, :-1, [2, 3], 0] += 0.2		# Produces correct conical surface for of_dist='.com'
 
 block_mesh_dict = BlockMeshDict(metric='mm', of_dist='.org')
 tube.write(block_mesh_dict)

--- a/examples/twisted_cavity.py
+++ b/examples/twisted_cavity.py
@@ -22,7 +22,7 @@ ndz = 1
 
 cavity = CartBlockStruct(xs, ys, zs, ndx, ndy, ndz, zone_tag=ZoneTag('fluid_zone'))
 
-GD = cavity['grading']
+GD = cavity.grading
 edge_grd = 4
 GD[:, 0, :, 1] = SimpleGradingElement(edge_grd)  # bottom
 GD[:, -2, :, 1] = SimpleGradingElement(1 / edge_grd)  # top
@@ -30,7 +30,7 @@ GD[0, :, :, 0] = SimpleGradingElement(edge_grd)  # left
 GD[-2, :, :, 0] = SimpleGradingElement(1 / edge_grd)  # right
 
 # Rotate vertices
-vts = cavity['vertices']
+vts = cavity.vertices
 XS, YS = vts[:, :, :, 0], vts[:, :, :, 1]
 RS = np.sqrt(XS ** 2 + YS ** 2)
 TS = np.arctan2(YS, XS)
@@ -42,10 +42,10 @@ XS[:] = RS * np.cos(TS)
 YS[:] = RS * np.sin(TS)
 
 # Set middle block to solid
-cavity['zone_tags'][2, 2, 0] = ZoneTag('solid_zone')
+cavity.zone_tags[2, 2, 0] = ZoneTag('solid_zone')
 
 # Label the lid
-cavity['boundary_tags'][:, -1, :, 1] = BoundaryTag('lid')
+cavity.boundary_tags[:, -1, :, 1] = BoundaryTag('lid')
 
 block_mesh_dict = BlockMeshDict(metric='mm')
 cavity.write(block_mesh_dict)

--- a/examples/wedge.py
+++ b/examples/wedge.py
@@ -23,8 +23,8 @@ nz = 10
 wedge = TubeBlockStruct(rs, ts, zs, nr, nt, nz, zone_tag='wedge')
 
 # Tag front and back boundaries
-wedge['boundary_tags'][..., 0, 2] = BoundaryTag('front')
-wedge['boundary_tags'][..., -1, 2] = BoundaryTag('back')
+wedge.boundary_tags[..., 0, 2] = BoundaryTag('front')
+wedge.boundary_tags[..., -1, 2] = BoundaryTag('back')
 
 # Initialize blockmeshbuilder to gather block structures.
 block_mesh_dict = BlockMeshDict(metric='mm', of_dist='.org')


### PR DESCRIPTION
Core builder classes have successfully subclassed numpy.recarray. Key new features are:

- accessing structured array fields using .baked_vertices instead of ['baked_vertices']
- sub-structures can be extracted using numpy slicing, and operated on using class member functions like `project_structure` and `write`

Notably, flipping block structures using an index like `[::-1]` or other manipulations such as `numpy.moveaxis` hasn't been tested and still likely won't work well, but I can't imagine any use cases for these right now. Also, numpy advanced indexing hasn't been thoroughly tested.